### PR TITLE
Branch name validation.

### DIFF
--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -1,4 +1,4 @@
-name: Java CI with Maven
+name: CI branch naming validation
 
 on:
   push:
@@ -7,19 +7,49 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
-
+  validate-branch:
+    name: Validate Branch Name
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - name: Determine branch name
+        id: get_ref
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "branch_name=${{ github.head_ref }}" >> $GITHUB_OUTPUT
+          else
+            echo "branch_name=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          fi
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Build with Maven
-        run: mvn -B package --file pom.xml
+      - name: Validate branch or tag name
+        run: |
+          ci_ref_name="${{ steps.get_ref.outputs.branch_name }}"
+          echo "Checking ref: $ci_ref_name"
+          
+          tag_pattern="^v[0-9]{1,2}\.[0-9]{1,3}\.[0-9]{1,3}$"
+          branch_pattern="^(feature|release|hotfix)/[a-zA-Z]{2,10}-[0-9]{1,5}"
+          sit_pattern="^sit/sit-"
+          release_pattern="^release/[Rr]elease_[0-9]{4}\.[0-9]{2}\.[0-9]{2}"
+          release_tag_pattern="^release/v[0-9]{1,2}\.[0-9]{1,3}\.[0-9]{1,3}"
+          
+          if [[ "$ci_ref_name" =~ $tag_pattern || "$ci_ref_name" =~ $branch_pattern || "$ci_ref_name" =~ $release_pattern || "$ci_ref_name" =~ $release_tag_pattern || "$ci_ref_name" == "main" || "$ci_ref_name" == "develop" || "$ci_ref_name" =~ $sit_pattern ]]; then
+            echo "✅ Branch name or tag is valid"
+          else
+            echo "❌ Branch name or tag is invalid"
+            echo "Refer to this document: https://m2-com.atlassian.net/wiki/spaces/tech/pages/347668627/Git+branch+CICD"
+            echo "Branch/tag must match one of the following patterns:"
+            echo " - feature/<JIRA-ID>-comment"
+            echo " - hotfix/<JIRA-ID>-comment"
+            echo " - sit/sit-comment"
+            echo " - release/Release_YYYY.MM.DD"
+            echo " - release/vX.Y.Z"
+            echo " - tag: vX.Y.Z"
+            echo ""
+            echo "Examples:"
+            echo " - v1.2.01"
+            echo " - feature/FUT-007"
+            echo " - sit/sit-xyz"
+            echo " - hotfix/GROW-33"
+            echo " - release/Release_2024.06.28"
+            echo " - release/v1.2.01"
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+.idea/
+*.iml


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to validate branch and tag naming conventions instead of running the Java CI build. The changes introduce a new job to ensure branch/tag names follow predefined patterns, improving consistency and adherence to the project's naming standards.

### Workflow updates for branch/tag validation:

* [`.github/workflows/java.yaml`](diffhunk://#diff-bffeb47f1f647e90b72eeca6ff0360e887de8abd1d7838204911a4fc4beb8b55L1-R1): Renamed the workflow from "Java CI with Maven" to "CI branch naming validation" and replaced the `build` job with a new `validate-branch` job. The job determines the branch or tag name and validates it against specific patterns, such as `feature/<JIRA-ID>-comment` or `release/vX.Y.Z`. If the name is invalid, the job provides guidance and examples for correct naming conventions. [[1]](diffhunk://#diff-bffeb47f1f647e90b72eeca6ff0360e887de8abd1d7838204911a4fc4beb8b55L1-R1) [[2]](diffhunk://#diff-bffeb47f1f647e90b72eeca6ff0360e887de8abd1d7838204911a4fc4beb8b55L10-R55)